### PR TITLE
add column 'responder_timeout' to structure.json

### DIFF
--- a/doc/structure.json
+++ b/doc/structure.json
@@ -1,5 +1,5 @@
 {
-    "tables": {        
+    "tables": {
         "lhc_twilio_chat": [
             {
                 "field": "id",
@@ -124,12 +124,12 @@
                 "extra": ""
             }
         ]
-    },  
+    },
     "tables_data": {    },
     "tables_data_identifier": {    },
     "tables_indexes" : {    },
     "tables_create": {
     	"lhc_twilio_chat" : "CREATE TABLE `lhc_twilio_chat` (  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `chat_id` bigint(20) unsigned NOT NULL, `phone` varchar(35) NOT NULL, `ctime` int(11) NOT NULL, `utime` int(11) NOT NULL, `tphone_id` int(11) NOT NULL, PRIMARY KEY (`id`),  KEY `phone_utime` (`phone`,`utime`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8",
-    	"lhc_twilio_phone" : "CREATE TABLE `lhc_twilio_phone` (  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `base_phone` varchar(35) NOT NULL, `phone` varchar(35) NOT NULL,`originator` varchar(35) NOT NULL, `account_sid` varchar(35), `auth_token` varchar(35), `dep_id` int(11) unsigned NOT NULL, `chat_timeout` int(11) unsigned NOT NULL, PRIMARY KEY (`id`), KEY `phone` (`phone`)) ENGINE=InnoDB DEFAULT CHARSET=utf8"
+    	"lhc_twilio_phone" : "CREATE TABLE `lhc_twilio_phone` (  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, `base_phone` varchar(35) NOT NULL, `phone` varchar(35) NOT NULL,`originator` varchar(35) NOT NULL, `account_sid` varchar(35), `auth_token` varchar(35), `dep_id` int(11) unsigned NOT NULL, `chat_timeout` int(11) unsigned NOT NULL, `responder_timeout` int(11) unsigned NOT NULL, PRIMARY KEY (`id`), KEY `phone` (`phone`)) ENGINE=InnoDB DEFAULT CHARSET=utf8"
     }
 }


### PR DESCRIPTION
The missing column was causing an error when adding a phone number on a fresh install using CLI to init SQL.