### PR TITLE
Fix twilio (whatsapp) pdf extension

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -2,7 +2,7 @@
 
 class erLhcoreClassExtensionTwilio
 {
-    public function __construct()
+    public function __construct()processMMSAttatchements
     {}
 
     private $settings = array();
@@ -585,6 +585,7 @@ class erLhcoreClassExtensionTwilio
                             'image/gif' => 'gif',
                             'image/png' => 'png',
                             'image/jpeg' => 'jpg',
+                            'application/pdf' => 'pdf',
                         );
 
                         $fileUpload = new erLhcoreClassModelChatFile();

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -2,7 +2,7 @@
 
 class erLhcoreClassExtensionTwilio
 {
-    public function __construct()processMMSAttatchements
+    public function __construct()
     {}
 
     private $settings = array();


### PR DESCRIPTION
Bug fix: if visitor uploaded a pdf file via twilio (whatsapp), the pdf file was saved with extension jpg